### PR TITLE
Receive and Send are now separate methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wcag-crawler",
-  "version": "1.0.0",
-  "description": "",
+  "version": "1.0.1",
+  "description": "A Cloud Function version of G5's Wrapper for Axe-Core",
   "main": "src/index.js",
   "scripts": {
     "start": "NODE_ENV=production node src/index.js",

--- a/src/audit.js
+++ b/src/audit.js
@@ -204,7 +204,7 @@ module.exports = class Audit {
       })
     } catch (error) {
       console.error(`ERROR Uable to post successfully: ${error}`)
-      axios.post('http://localhost:7564/api/v1/wcag/intake', {
+      axios.post(`${host}/api/v1/wcag/intake`, {
         error,
         id
       }).catch(error => console.error(`ERROR Unable to post error: ${error}`))

--- a/src/audit.js
+++ b/src/audit.js
@@ -1,4 +1,5 @@
 const { AxePuppeteer } = require('@axe-core/puppeteer')
+const axios = require('axios')
 const puppeteer = require('puppeteer')
 const userImpact = require('./user-impact')
 
@@ -35,6 +36,9 @@ module.exports = class Audit {
     this.includeWcag21aa = params.includeWcag21aa
     this.passCounts = passCounts
     this.summary = summary
+    this.clientURN = params.clientURN
+    this.locationUrn = params.locationUrn
+    this.id = params.id
   }
 
   /**
@@ -94,14 +98,19 @@ module.exports = class Audit {
   }
 
   async run () {
-    await this.bootBrowser()
-    await this.newPage()
-    await this.page.setBypassCSP(true)
-    while (this.pages.length > 0) {
-      const url = this.pages.pop()
-      await this.changeUrl(url)
-      await this.auditPage()
-      this.auditedPages.push(url)
+    try {
+      await this.bootBrowser()
+      await this.newPage()
+      await this.page.setBypassCSP(true)
+      while (this.pages.length > 0) {
+        const url = this.pages.pop()
+        await this.changeUrl(url)
+        console.log(`AUDIT ${url}`)
+        await this.auditPage()
+        this.auditedPages.push(url)
+      }
+    } catch (error) {
+      throw new Error(error, this)
     }
     await this.closePage()
     await this.closeBrowser()
@@ -179,6 +188,27 @@ module.exports = class Audit {
       this.summary[objectKey][set.id] = 0
     }
     this.summary[objectKey][set.id]++
+  }
+
+  /**
+   * Sends new network request back to audit requester
+   * @param {Object} results 
+   */
+  async send (host, results = this.results) {
+    try {
+      await axios.post(`${host}/api/v1/wcag/intake`, {
+        results,
+        id: this.id,
+        clientURN: this.clientURN,
+        locationUrn: this.locationUrn
+      })
+    } catch (error) {
+      console.error(`ERROR Uable to post successfully: ${error}`)
+      axios.post('http://localhost:7564/api/v1/wcag/intake', {
+        error,
+        id
+      }).catch(error => console.error(`ERROR Unable to post error: ${error}`))
+    }
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ app.use(json({ limit: '1000kb' }))
 
 if (process.env.NODE_ENV !== 'production') {
   app.use((req, res, next) => {
-    console.log(req.path, req.body)
+    console.log(`${req.protocol}://${req.hostname}`, req.body)
     next()
   })
 }
@@ -18,9 +18,13 @@ app.get('/', (req, res) => res.status(200).send('I\'m Listening.'))
 
 app.post('/', async (req, res) => {
   try {
+    const client = process.env.NODE_ENV !== 'production'
+      ? `${req.protocol}://${req.hostname}:7564`
+      : `${req.protocol}://${req.hostname}`
     const audit = new Audit(req.body)
+    res.sendStatus(201)
     await audit.run()
-    res.json(audit.results)
+    await audit.send(client, audit.results)
   } catch (error) {
     res.send(error)
   }


### PR DESCRIPTION
- Forgive the misnamed branch. Abandoned PubSub for the time being.
- Adds `send()` method to the Audit class that sends the response of the audit once complete.
- Enhanced logging for Cloud Run log filters.